### PR TITLE
Node 11 is fixed, so let's remove this.

### DIFF
--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -80,7 +80,7 @@ describe('resolve-package-path', function() {
           app.pkg.private = true;
           app.pkg.name
           app.pkg.scripts = {
-            test: "node -r ./.pnp.js ./test.js"
+            test: "node ./test.js"
           };
           app.pkg.installConfig = {
             pnp: true


### PR DESCRIPTION
When a script is invoked by yarn, it provides the appropriate -r via NODE_OPTIONS to automatically be pnp aware. Previously NODE_OPTIONS was partially broken in node 11, preventing `yarn` `pnp` from working.

Relevant issue: https://github.com/nodejs/node/issues/26521