### PR TITLE
stronger return type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ try {
  * @return {string|null} a full path to the resolved package.json if found or null if not
  */
 export = resolvePackagePath;
-function resolvePackagePath(target: string, basedir: string, _cache?: CacheGroup | boolean) {
+function resolvePackagePath(target: string, basedir: string, _cache?: CacheGroup | boolean): string | null {
   let cache;
 
   if (_cache === undefined || _cache === null || _cache === true) {


### PR DESCRIPTION
Typescript was not able to infer this, it's currently typed as `any`, which means that code that calls this library doesn't get type checking for things like the `null` return case.