### PR TITLE
[bug] ensures that repository link is available on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "resolve-package-path",
   "description": "a special purpose fast memoizing way to resolve a node modules package.json",
   "version": "2.0.0",
+  "repository": "git@github.com:stefanpenner/resolve-package-path.git",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
 <img width="480" alt="Screen Shot 2020-09-22 at 5 57 42 PM" src="https://user-images.githubusercontent.com/1854811/93952197-1d7edc00-fcfd-11ea-816a-57f03ef8abeb.png">

repo link didn't exist on npmjs.com