### PR TITLE
Add findUpPackagePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # resolve-package-path ![CI](https://github.com/stefanpenner/resolve-package-path/workflows/CI/badge.svg)
 
-This project is special-purpose, made to resolve a package.json file
-given a specific module name and basedir to start searching from. It
-cannot and does not resolve anything else.
+This project is special-purpose, made to resolve `package.json` files for:
+
+  - a given module name and basedir or
+  - a given basedir
+
+It cannot and does not resolve anything else.
 
 To achieve its file-resolution performance, it does two specific things:
 
@@ -22,7 +25,10 @@ yarn add resolve-package-path
 ```js
 const resolvePackagePath = require('resolve-package-path');
 
-resolvePackagePath('rsvp', 'base-dir/to/start/the/node_resolution-algorithm-from') => // /path/to/rsvp.json or null
+resolvePackagePath('rsvp', 'base-dir/to/start/the/node_resolution-algorithm-from') // => /path/to/rsvp.json or null
+
+const { findUpPackagePath } = resolvePackagePath;
+findUpPackagePath('base-dir/to/start') // => path/to/package.json or null
 ```
 
 ## Advanced usage
@@ -38,7 +44,10 @@ Although by default `resolve-package-path` caches or memoizes results, this feat
 ```js
 const resolvePackagePath = require('resolve-package-path');
 
-resolvePackagePath('rsvp', 'base-dir/to/start/the/node_resolution-algorithm-from', false) => // uncached result /path/to/rsvp.json or null
+resolvePackagePath('rsvp', 'base-dir/to/start/the/node_resolution-algorithm-from', false) // => uncached result /path/to/rsvp.json or null
+
+const { findUpPackagePath } = resolvePackagePath;
+findUpPackagePath('base-dir/to/start', false) // => path/to/package.json or null
 ```
 
 ### Purge the cache
@@ -59,9 +68,13 @@ cache = {
   REAL_FILE_PATH: new Map(),
   REAL_DIRECTORY_PATH: new Map(),
 };
+findUpCache = new Map();
 
 const resolvePackagePath = require('resolve-package-path');
 resolvePackagePath('rsvp', 'path/to/start/from', cache);
+
+const { findUpPackagePath } = resolvePackagePath;
+findUpPackagePath('base-dir/to/start', findUpCache) // => path/to/package.json or null
 ```
 
 ### Use internal helper functions

--- a/lib/resolve-package-path.d.ts
+++ b/lib/resolve-package-path.d.ts
@@ -3,6 +3,7 @@ import CacheGroup = require('./cache-group');
 declare function resolvePackagePath(caches: CacheGroup, name?: string, dir?: string): string | null;
 declare namespace resolvePackagePath {
     var _findPackagePath: (realFilePathCache: Cache, name: string, dir: string) => string | null;
+    var _findUpPackagePath: (findUpCache: Cache, initialSearchDir: string) => string | null;
     var _getRealFilePath: (realFilePathCache: Cache, filePath: string) => string | null;
     var _getRealDirectoryPath: (realDirectoryPathCache: Cache, directoryPath: string) => string | null;
 }


### PR DESCRIPTION
This finds the nearest `package.json` on the path to root from some initial search path.  Has a similar caching strategy to `findPackagePath`.
